### PR TITLE
Fixed regarding nuget and plain refs…

### DIFF
--- a/Nuget/Nuget.cs
+++ b/Nuget/Nuget.cs
@@ -29,11 +29,138 @@ namespace PackageMagic.Nuget
         {
             List<IMagicPackage> result = new List<IMagicPackage>();
 
-            result.AddRange(await PopulatePackageReferences(path));
-            result.AddRange(await SearchForPackagesConfig(path));
+            result.AddRange(await AddFromCsProj(path));
+            result.AddRange(await AddFromPackagesConfig(path));
 
             return result;
         }
+
+        /// <summary>
+        /// Searches for packages configuration. (packages.config)
+        /// </summary>
+        /// <param name="projectFile">The project file.</param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IMagicPackage>> AddFromPackagesConfig(string projectFile) => await Task.Run(() =>
+        {
+            List<NugetPackage> result = new List<NugetPackage>();
+
+            var packagesFile = Path.Combine(Path.GetDirectoryName(projectFile), "packages.config");
+
+            if (File.Exists(packagesFile))
+            {
+                var file = new PackageReferenceFile(packagesFile);
+
+                foreach (PackageReference packageReference in file.GetPackageReferences())
+                {
+                    var package = new NugetPackage { Name = packageReference.Id, Version = packageReference.Version.ToNormalizedString(), Description = projectFile, PackageType = MagicPackageType.PackageConfig };
+                    result.Add(package);
+                }
+            }
+
+            return result;
+        });
+
+        /// <summary>
+        /// Adds package references from CsProj/>
+        /// </summary>
+        /// <param name="projectDirectory">The project directory.</param>
+        /// <returns></returns>
+        private async Task<IEnumerable<IMagicPackage>> AddFromCsProj(string projectFile)
+        {
+            List<NugetPackage> result = new List<NugetPackage>();
+            XmlDocument xDoc = new XmlDocument();
+            string bareFilename = Path.GetFileName(projectFile);
+
+            using (var fs = new FileStream(projectFile, FileMode.Open))
+            {
+                xDoc.Load(fs);
+                bool isCore = false;
+
+                isCore = IsNetCore(xDoc);
+
+                if (!isCore)
+                {
+                    string targetFrameworkVersion = GetFrameworkVersion(xDoc);
+
+                    //Then get normal references
+                    var nodes = xDoc.GetElementsByTagName("Reference");
+                    foreach (XmlNode node in nodes)
+                    {
+                        if (node.Attributes != null && node.Attributes.Count > 0)
+                        {
+                            string packageName = node.Attributes["Include"] == null ? "" : node.Attributes["Include"].Value;
+                            string packageVersion = node.Attributes["Version"] == null ? "" : node.Attributes["Version"].Value;
+                            if (string.IsNullOrEmpty(packageVersion))
+                            {
+                                var versionNode = node.SelectSingleNode("Version") ?? null;
+                                if (versionNode != null)
+                                {
+                                    packageVersion = versionNode.Value ?? "";
+                                }
+                            }
+
+                            packageVersion = string.IsNullOrEmpty(packageVersion) ? targetFrameworkVersion : packageVersion;
+
+                            result.Add(new NugetPackage { Name = packageName, Version = packageVersion, Description = "", PackageType = MagicPackageType.Reference });
+                        }
+                    }
+
+                    //Then get new nuget references
+                    nodes = xDoc.GetElementsByTagName("PackageReference");
+                    foreach (XmlNode node in nodes)
+                    {
+                        if (node.Attributes != null && node.Attributes.Count > 0)
+                        {
+                            string packageVersion = "";
+                            var packageName = node.Attributes["Include"].Value;
+                            if (node.Attributes["Version"] != null)
+                            {
+                                packageVersion = node.Attributes["Version"].Value;
+                            }
+                            else
+                            {
+                                var versionNodes = node.SelectNodes("Version");
+                                if (versionNodes != null&& versionNodes.Count>0)
+                                {
+                                    packageVersion = versionNodes[0].Value;
+                                }
+                            }
+                            result.Add(new NugetPackage { Name = packageName, Version = packageVersion, Description = "", PackageType = MagicPackageType.PackageReference });
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static string GetFrameworkVersion(XmlDocument xDoc)
+        {
+            var nodeFramework = xDoc.GetElementsByTagName("TargetFrameworkVersion");
+
+            if (nodeFramework == null || nodeFramework.Count == 0)
+                return "";
+
+            return nodeFramework.Item(0).ChildNodes[0].Value ?? "";
+        }
+
+        private bool IsNetCore(XmlDocument xDoc)
+        {
+            XmlElement root = xDoc.DocumentElement;
+            if (root.Attributes != null && root.Attributes.Count > 0)
+            {
+                if (root.Attributes["Sdk"] != null && root.Attributes["Sdk"].Value == "Microsoft.NET.Sdk")
+                    return true;
+                if (root.Attributes["Sdk"] != null && root.Attributes["Sdk"].Value == "Microsoft.NET.Sdk.Web")
+                    return true;
+            }
+            return false;
+        }
+
+
+
+
+
 
         /// <summary>
         /// Loads the nuget feed provided. Loops all packages and adds them to PackageInformation List.
@@ -102,46 +229,6 @@ namespace PackageMagic.Nuget
             return result;
         });
 
-        /// <summary>
-        /// Searches for packages configuration. (packages.config)
-        /// </summary>
-        /// <param name="projectFile">The project file.</param>
-        /// <returns></returns>
-        private async Task<IEnumerable<IMagicPackage>> SearchForPackagesConfig(string projectFile) => await Task.Run(() =>
-       {
-           List<NugetPackage> result = new List<NugetPackage>();
-
-           var packagesFile = Path.Combine(Path.GetDirectoryName(projectFile), "packages.config");
-
-           #region MyRegion
-
-           //xml = new XmlSerializer(typeof(Packages));
-           //reader = new StreamReader(packConfig);
-           //settings = (Packages)xml.Deserialize(reader);
-
-           ////var file = new PackageReferenceFile(packConfig);
-           //foreach (var packageReference in settings.Package)
-           //{
-
-           //    Utils.LogMessages(packageReference, true);
-
-           //    //await Utils.AddToPackageInformation(new PackageInformation { PackageName = packageReference.Id, PackageVersion = packageReference.Version.ToNormalizedString(), PackageDescription = foundCsProjFile, OriginOfPackage = PackageInformation.Origin.PackageConfig, CsProjFile = foundCsProjFile });
-           //    Utils.AddToPackageInformation(new PackageInformation { PackageName = packageReference.Id, PackageVersion = packageReference.Version.to, PackageDescription = foundCsProjFile, OriginOfPackage = PackageInformation.Origin.PackageConfig, CsProjFile = foundCsProjFile }).GetAwaiter().GetResult();
-
-           //}
-
-           #endregion
-
-           var file = new PackageReferenceFile(packagesFile);
-           foreach (PackageReference packageReference in file.GetPackageReferences())
-           {
-               var package = new NugetPackage { Name = packageReference.Id, Version = packageReference.Version.ToNormalizedString(), Description = projectFile, PackageType = MagicPackageType.PackageConfig };
-               result.Add(package);
-           }
-
-           return result;
-       });
-
         // private async Task GetNugetPackageInformation() => await Task.Run(() =>
         //{
         //    IPackage pack;
@@ -156,23 +243,6 @@ namespace PackageMagic.Nuget
         //        PackageService.Utils.LogMessages(pack.Id, true);
         //    }
         //});
-
-        /// <summary>
-        /// Populates the package references and calls <see cref="SearchCsProj"/>
-        /// </summary>
-        /// <param name="projectDirectory">The project directory.</param>
-        /// <returns></returns>
-        private async Task<IEnumerable<IMagicPackage>> PopulatePackageReferences(string projectDirectory)
-        {
-            //List<IMagicPackage> temp = new List<IMagicPackage>();
-            //string[] csProjFiles = Directory.GetFiles(projectDirectory, "*.csproj", SearchOption.AllDirectories);
-            //foreach (var csProjFile in csProjFiles)
-            //{
-            //    temp.AddRange(await SearchCsProj(csProjFile));
-            //}
-            //return temp;
-            return await SearchCsProj(projectDirectory);
-        }
 
         //public static async Task AddToPackageInformation(NugetPackage package)
         //{


### PR DESCRIPTION
Believe I got all references included now, plain refs, nuget refs embedded in csproj and nuget refs in packages.config. Plain refs are versioned with attribute TargetFrameworkVersion from the csproj. DotNet Core and UWP is not yet properly handled due to differences in how they save references